### PR TITLE
Update dependencies to use version 3.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "vscode-ibmi-fs",
-  "version": "0.0.7-dev0",
+  "version": "0.0.8-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-ibmi-fs",
-      "version": "0.0.7-dev0",
+      "version": "0.0.8-dev0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/fast-element": "^2.10.0",
         "@vscode-elements/elements": "^2.5.1"
       },
       "devDependencies": {
-        "@halcyontech/vscode-ibmi-types": "^2.17.2",
+        "@halcyontech/vscode-ibmi-types": "^3.0.6",
         "@types/node": "^20",
         "@types/vscode": "^1.90.0",
         "@vscode/l10n-dev": "^0.0.35",
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@halcyontech/vscode-ibmi-types": {
-      "version": "2.17.2",
-      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-2.17.2.tgz",
-      "integrity": "sha512-ahygUkvnJeiaPnOhPMAyp9AJ9X1Sq3SvaXd8Uh11TUdOZxQdRP2P7O2agIfLBR7KUw+ZC1GEypRAgE01YV9QyQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@halcyontech/vscode-ibmi-types/-/vscode-ibmi-types-3.0.6.tgz",
+      "integrity": "sha512-DEO+BAWlM5soOdXm4m5f0XPkGr50YhnqT2fGWTXvErMagY3M4QdtnECocpZswYJ8AoYCs2wCppjWnS42GahB+Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -698,13 +698,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.16.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.9.tgz",
-      "integrity": "sha512-rkvIVJxsOfBejxK7I0FO5sa2WxFmJCzoDwcd88+fq/CUfynNywTo/1/T6hyFz22CyztsnLS9nVlHOnTI36RH5w==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -1005,7 +1005,6 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1039,7 +1038,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1148,7 +1146,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -3300,9 +3297,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3374,7 +3371,6 @@
       "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -3422,7 +3418,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "%displayName%",
   "description": "%description%",
   "l10n": "./l10n",
-  "version": "0.0.8-dev0",
+  "version": "0.0.9-dev0",
   "preview": true,
   "license": "MIT",
   "engines": {
@@ -678,8 +678,7 @@
         }
       ]
     },
-    "keybindings": [
-    ]
+    "keybindings": []
   },
   "scripts": {
     "clean": "rimraf dist",
@@ -692,7 +691,7 @@
     "pseudo-nls": "npx @vscode/l10n-dev generate-pseudo -o ./l10n/ ./l10n/bundle.l10n.json ./package.nls.json"
   },
   "devDependencies": {
-    "@halcyontech/vscode-ibmi-types": "^2.17.2",
+    "@halcyontech/vscode-ibmi-types": "^3.0.6",
     "@types/node": "^20",
     "@types/vscode": "^1.90.0",
     "@vscode/l10n-dev": "^0.0.35",

--- a/src/commonOperations.ts
+++ b/src/commonOperations.ts
@@ -19,7 +19,6 @@ import { CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { getInstance } from './ibmi';
 import { checkTableFunctionExists } from './tools';
 import { posix } from 'path';
-import { Config } from '@halcyontech/vscode-ibmi-types/api/configuration/config/VirtualConfig';
 
 /**
  * Interface representing a job identifier

--- a/src/commonOperations.ts
+++ b/src/commonOperations.ts
@@ -351,7 +351,7 @@ export namespace SpoolOperations {
         // Execute CPYSPLF command to copy spool to stream file
         const result = await connection.runCommand({
           command: `QSYS/CPYSPLF FILE(${spoolId.spoolname}) JOB(${spoolId.job}) SPLNBR(${spoolId.nbr}) TOFILE(*TOSTMF) TOSTMF('${tempSourcePath}')
-            CPY OBJ('${tempSourcePath}') TOOBJ('${tempSourcePath}') TOCCSID(*PCASCII) DTAFMT(*TEXT) REPLACE(*YES)`,
+            QSYS/CPY OBJ('${tempSourcePath}') TOOBJ('${tempSourcePath}') TOCCSID(1208) DTAFMT(*TEXT) REPLACE(*YES)`,
           environment: 'ile'
         });
 

--- a/src/ibmi.ts
+++ b/src/ibmi.ts
@@ -1,8 +1,6 @@
 import { CodeForIBMi } from "@halcyontech/vscode-ibmi-types";
-import { CustomUI } from "@halcyontech/vscode-ibmi-types/webviews/CustomUI";
 import Instance from "@halcyontech/vscode-ibmi-types/Instance";
 import { VscodeTools } from "@halcyontech/vscode-ibmi-types/ui/Tools";
-import { DeployTools } from "@halcyontech/vscode-ibmi-types/filesystems/local/deployTools";
 import { Extension, extensions } from "vscode";
 
 /** Reference to the base Code for IBM i extension */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,5 +1,4 @@
 import IBMi from '@halcyontech/vscode-ibmi-types/api/IBMi';
-import { getInstance } from "./ibmi";
 import { Components } from "./webviewToolkit";
 import { ObjectFilters } from '@halcyontech/vscode-ibmi-types';
 import * as vscode from 'vscode';

--- a/src/types/base.ts
+++ b/src/types/base.ts
@@ -1,4 +1,4 @@
-import { CustomDocument, Uri, extensions } from "vscode";
+import { CustomDocument, Uri } from "vscode";
 import {} from "@halcyontech/vscode-ibmi-types/api/IBMi";
 
 /**

--- a/src/types/bindingDirectory.ts
+++ b/src/types/bindingDirectory.ts
@@ -22,7 +22,7 @@ import * as vscode from 'vscode';
 import { Components } from "../webviewToolkit";
 import Base from "./base";
 import { getInstance } from '../ibmi';
-import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, checkViewExists, executeSqlIfExists } from "../tools";
+import { FastTableColumn, generateFastTable, getProtected, executeSqlIfExists } from "../tools";
 import ObjectProvider from '../objectProvider';
 
 /**

--- a/src/types/class.ts
+++ b/src/types/class.ts
@@ -25,7 +25,7 @@
 
 import Base from "./base";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, checkProcedureExists, checkViewExists, checkTableFunctionExists } from "../tools";
+import { generateDetailTable, checkProcedureExists, checkViewExists, checkTableFunctionExists } from "../tools";
 import * as vscode from 'vscode';
 import { CommandResult } from "@halcyontech/vscode-ibmi-types";
 

--- a/src/types/command.ts
+++ b/src/types/command.ts
@@ -20,7 +20,7 @@
 
 import Base from "./base";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, executeSqlIfExists } from "../tools";
 import * as vscode from 'vscode';
 
 /**

--- a/src/types/dataArea.ts
+++ b/src/types/dataArea.ts
@@ -15,9 +15,8 @@
 
 import Base from "./base";
 import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
-import { Components } from "../webviewToolkit";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, getProtected, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, getProtected, executeSqlIfExists } from "../tools";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
 import ObjectProvider from '../objectProvider';

--- a/src/types/dataQueue.ts
+++ b/src/types/dataQueue.ts
@@ -21,7 +21,7 @@ import * as vscode from 'vscode';
 import { Components } from "../webviewToolkit";
 import Base from "./base";
 import { getInstance } from '../ibmi';
-import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, checkProcedureExists, checkTableFunctionExists, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, executeSqlIfExists } from "../tools";
 import ObjectProvider from '../objectProvider';
 
 /**

--- a/src/types/ddmFile.ts
+++ b/src/types/ddmFile.ts
@@ -18,13 +18,9 @@ import {
   CommandResult
 } from "@halcyontech/vscode-ibmi-types";
 import * as vscode from "vscode";
-import {
-  generateDetailTable,
-  getQSYSObjectPath,
-} from "../tools";
+import { generateDetailTable } from "../tools";
 import Base from "./base";
 import { getInstance } from "../ibmi";
-import path = require("path");
 
 /**
  * Regular expression for parsing DDM file header information from DSPDDMF output
@@ -62,6 +58,7 @@ export class DdmFile extends Base {
       const ddmf: CommandResult = await connection.runCommand({
         command: `QSYS/DSPDDMF FILE(${this.library}/${this.name})`,
         environment: `ile`,
+        getSpooledFiles:true,
       });
 
       if (ddmf.code === 0 && ddmf.stdout) {

--- a/src/types/dummyObject.ts
+++ b/src/types/dummyObject.ts
@@ -13,7 +13,6 @@
 
 import Base from "./base";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable } from "../tools";
 import * as vscode from 'vscode';
 import { CommandResult } from "@halcyontech/vscode-ibmi-types";
 
@@ -110,14 +109,14 @@ export async function fetchQrydfn(library: string, object: string): Promise<stri
     let sql ='--SQL translation for *QRYDFN: '+library+'/'+object+'\n\n';
 
     let cmdrun: CommandResult = await connection.runCommand({
-      command: `CHKOBJ OBJ(${connection.getConfig().tempLibrary}/DUMMYSRCPF) OBJTYPE(*FILE)`,
+      command: `CHKOBJ OBJ(QTEMP/DUMMYSRCPF) OBJTYPE(*FILE)`,
       environment: `ile`
     });
 
     // Check command execution result
     if (cmdrun.code !== 0) {
       cmdrun = await connection.runCommand({
-        command: `CRTSRCPF FILE(${connection.getConfig().tempLibrary}/DUMMYSRCPF) RCDLEN(200)`,
+        command: `CRTSRCPF FILE(QTEMP/DUMMYSRCPF) RCDLEN(200)`,
         environment: `ile`
       });
       if (cmdrun.code !== 0) {
@@ -127,7 +126,7 @@ export async function fetchQrydfn(library: string, object: string): Promise<stri
     } 
     
     cmdrun = await connection.runCommand({
-      command: `RTVQMQRY QMQRY(${library}/${object}) SRCFILE(${connection.getConfig().tempLibrary}/DUMMYSRCPF) ALWQRYDFN(*YES)`,
+      command: `RTVQMQRY QMQRY(${library}/${object}) SRCFILE(QTEMP/DUMMYSRCPF) ALWQRYDFN(*YES)`,
       environment: `ile`
     });
 
@@ -137,12 +136,12 @@ export async function fetchQrydfn(library: string, object: string): Promise<stri
     }
 
     try{
-      await connection.runSQL(`CREATE ALIAS ${connection.getConfig().tempLibrary}.${object} FOR  ${connection.getConfig().tempLibrary}.DUMMYSRCPF(${object})`);
+      await connection.runSQL(`CREATE ALIAS QTEMP.${object} FOR  QTEMP.DUMMYSRCPF(${object})`);
       let qrydfn = await connection.runSQL(`select srcdta 
-          from ${connection.getConfig().tempLibrary}.${object} x 
+          from QTEMP.${object} x 
           where rrn(x) >= (
             select rrn(Y) 
-            from ${connection.getConfig().tempLibrary}.${object} Y 
+            from QTEMP.${object} Y 
             where srcdta like '%SELECT%'
           )`);
       for (const row of qrydfn) {
@@ -151,10 +150,10 @@ export async function fetchQrydfn(library: string, object: string): Promise<stri
       }
       
       cmdrun = await connection.runCommand({
-        command: `RMVM FILE(${connection.getConfig().tempLibrary}/DUMMYSRCPF) MBR(${object})`,
+        command: `RMVM FILE(QTEMP/DUMMYSRCPF) MBR(${object})`,
         environment: `ile`
       });
-      await connection.runSQL(`DROP ALIAS ${connection.getConfig().tempLibrary}.${object}`)
+      await connection.runSQL(`DROP ALIAS QTEMP.${object}`)
     } catch{
       vscode.window.showErrorMessage(vscode.l10n.t("Unable to create necessary objects for displaying query definitions."));
       return '';

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -17,14 +17,13 @@
  */
 
 import Base from "./base";
-import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
+import { IBMiObject } from '@halcyontech/vscode-ibmi-types';
 import { Components } from "../webviewToolkit";
 import { getInstance } from "../ibmi";
-import { generateDetailTable, getColumns, generateFastTable, FastTableColumn, getProtected, checkTableFunctionExists, checkViewExists, executeSqlIfExists } from "../tools";
+import { generateDetailTable, getColumns, generateFastTable, FastTableColumn, executeSqlIfExists } from "../tools";
 import { DocumentManager } from "../documentManager";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
-import ObjectProvider from '../objectProvider';
 
 /**
  * Namespace containing actions for FILE objects

--- a/src/types/jobDescription.ts
+++ b/src/types/jobDescription.ts
@@ -18,7 +18,7 @@
 
 import Base from "./base";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, executeSqlIfExists } from "../tools";
 import * as vscode from 'vscode';
 
 /**

--- a/src/types/jobQueue.ts
+++ b/src/types/jobQueue.ts
@@ -18,7 +18,7 @@ import Base from "./base";
 import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { Components } from "../webviewToolkit";
 import { getInstance } from "../ibmi";
-import { generateDetailTable, getColumns, generateFastTable, FastTableColumn, getProtected, checkTableFunctionExists, checkViewExists, executeSqlIfExists } from "../tools";
+import { generateDetailTable, getColumns, generateFastTable, FastTableColumn, getProtected, executeSqlIfExists } from "../tools";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
 import ObjectProvider from '../objectProvider';

--- a/src/types/journal.ts
+++ b/src/types/journal.ts
@@ -18,7 +18,7 @@ import Base from "./base";
 import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { Components } from "../webviewToolkit";
 import { getInstance } from "../ibmi";
-import { generateDetailTable, getColumns, generateFastTable, FastTableColumn, getProtected, checkTableFunctionExists, checkViewExists, executeSqlIfExists } from "../tools";
+import { generateDetailTable, getColumns, generateFastTable, FastTableColumn, getProtected, checkTableFunctionExists, executeSqlIfExists } from "../tools";
 import { DocumentManager } from "../documentManager";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';

--- a/src/types/journalReceiver.ts
+++ b/src/types/journalReceiver.ts
@@ -20,7 +20,7 @@
 
 import Base from "./base";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, executeSqlIfExists } from "../tools";
 import * as vscode from 'vscode';
 
 /**

--- a/src/types/messageFile.ts
+++ b/src/types/messageFile.ts
@@ -16,10 +16,9 @@
  */
 
 import Base from "./base";
-import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { getInstance } from "../ibmi";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
-import { generateFastTable, FastTableColumn, checkViewExists, executeSqlIfExists } from "../tools";
+import { generateFastTable, FastTableColumn, executeSqlIfExists } from "../tools";
 import * as vscode from 'vscode';
 
 /**

--- a/src/types/messageQueue.ts
+++ b/src/types/messageQueue.ts
@@ -20,7 +20,7 @@ import Base from "./base";
 import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { getInstance } from "../ibmi";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
-import { generateFastTable, FastTableColumn, getProtected, checkViewExists, executeSqlIfExists } from "../tools";
+import { generateFastTable, FastTableColumn, getProtected, executeSqlIfExists } from "../tools";
 import * as vscode from 'vscode';
 import ObjectProvider from "../objectProvider";
 

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -17,7 +17,7 @@
  * @module module
  */
 
-import { CommandResult, IBMiObject } from '@halcyontech/vscode-ibmi-types';
+import { CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
 import { Components } from "../webviewToolkit";
@@ -123,7 +123,7 @@ export class Module extends Base {
       this.columns = await getColumns(connection, 'QABNDMBA','QSYS');
 
       let cmdrun: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*BASIC) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*BASIC) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
 
@@ -196,10 +196,10 @@ export class Module extends Base {
           basqpx,
           bacnvd,
           baarcs
-        FROM ${connection.getConfig().tempLibrary}.${tmpfile}`);
+        FROM QTEMP.${tmpfile}`);
 
       cmdrun = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
     } else {
@@ -228,7 +228,7 @@ export class Module extends Base {
       this.columns2 = await getColumns(connection, 'QABNDMSI','QSYS');
 
       let cmdrun: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*SIZE) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*SIZE) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
 
@@ -275,10 +275,10 @@ export class Module extends Base {
           SIPLP CONCAT ' / ' CONCAT SIPLPL SIPLP,
           SIPLPN,
           SISTS8 CONCAT ' / ' CONCAT SISTSL8 SISTS8
-        FROM ${connection.getConfig().tempLibrary}.${tmpfile}`);
+        FROM QTEMP.${tmpfile}`);
 
       cmdrun = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
     } else {
@@ -304,12 +304,12 @@ export class Module extends Base {
       const tmpfile2=generateRandomString(10);
 
       let cmdrun1: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*IMPORT) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile1})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*IMPORT) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile1})`,
         environment: `ile`
       });
 
       let cmdrun2: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*EXPORT) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile2})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*EXPORT) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile2})`,
         environment: `ile`
       });
 
@@ -329,7 +329,7 @@ export class Module extends Base {
                         END AS SYMBOL_TYPE,
                         IMOPPP AS ARGUMENT_OPTIMIZATION,
                         'IMPORT' AS TYPEOF
-                      FROM ${connection.getConfig().tempLibrary}.${tmpfile1}
+                      FROM QTEMP.${tmpfile1}
                   UNION
                   SELECT exsynm AS symbol,
                         CASE EXSYTY
@@ -338,18 +338,18 @@ export class Module extends Base {
                         END AS SYMBOL_TYPE,
                         EXOPPP AS ARGUMENT_OPTIMIZATION,
                         'EXPORT' AS TYPEOF
-                      FROM ${connection.getConfig().tempLibrary}.${tmpfile2}
+                      FROM QTEMP.${tmpfile2}
               )
           ORDER BY typeof`);
         
       this.impexports.push(...entryRows.map(toExport));
       
       cmdrun1 = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile1})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile1})`,
         environment: `ile`
       });
       cmdrun1 = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile2})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile2})`,
         environment: `ile`
       });
     } else {
@@ -373,7 +373,7 @@ export class Module extends Base {
       const tmpfile=generateRandomString(10);
 
       let cmdrun: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*PROCLIST) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*PROCLIST) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
 
@@ -390,12 +390,12 @@ export class Module extends Base {
               WHEN '1' THEN 'ENTRYPOINT'
           END AS PRCTYPE,
           PROPPP AS ARGUMENT_OPTIMIZATION
-        FROM ${connection.getConfig().tempLibrary}.${tmpfile}`);
+        FROM QTEMP.${tmpfile}`);
 
       this.procs.push(...entryRows.map(toEntry));
 
       cmdrun = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
     } else {
@@ -418,7 +418,7 @@ export class Module extends Base {
       const tmpfile=generateRandomString(10);
 
       let cmdrun: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*REFSYSOBJ) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*REFSYSOBJ) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
 
@@ -432,12 +432,12 @@ export class Module extends Base {
         SELECT reobnm,
           reolnm,
           reobty
-        FROM ${connection.getConfig().tempLibrary}.${tmpfile}`);
+        FROM QTEMP.${tmpfile}`);
 
       this.sysobj.push(...entryRows.map(toEntry2));
 
       cmdrun = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
     } else {
@@ -459,7 +459,7 @@ export class Module extends Base {
       const tmpfile=generateRandomString(10);
 
       let cmdrun: CommandResult = await connection.runCommand({
-        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*COPYRIGHT) OUTPUT(*OUTFILE) OUTFILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DSPMOD MODULE(${this.library}/${this.name}) DETAIL(*COPYRIGHT) OUTPUT(*OUTFILE) OUTFILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
 
@@ -471,12 +471,12 @@ export class Module extends Base {
       this.copyrights.length = 0;
       const entryRows = await connection.runSQL(`
         SELECT COPYRT
-        FROM ${connection.getConfig().tempLibrary}.${tmpfile}`);
+        FROM QTEMP.${tmpfile}`);
 
       this.copyrights.push(...entryRows.map(toCopyRight));
 
       cmdrun = await connection.runCommand({
-        command: `QSYS/DLTF FILE(${connection.getConfig().tempLibrary}/${tmpfile})`,
+        command: `QSYS/DLTF FILE(QTEMP/${tmpfile})`,
         environment: `ile`
       });
     } else {

--- a/src/types/outputQueue.ts
+++ b/src/types/outputQueue.ts
@@ -20,7 +20,7 @@ import Base from "./base";
 import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
 import { Components } from "../webviewToolkit";
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, generateFastTable, FastTableColumn, getProtected, checkTableFunctionExists, checkViewExists, checkProcedureExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, generateFastTable, FastTableColumn, getProtected, executeSqlIfExists } from "../tools";
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
 import ObjectProvider from '../objectProvider';

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -17,13 +17,12 @@
  * @module program
  */
 
-import { IBMiObject } from '@halcyontech/vscode-ibmi-types';
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
 import { Components } from "../webviewToolkit";
 import Base from "./base";
 import { getInstance } from '../ibmi';
-import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, executeSqlIfExists } from "../tools";
 
 /**
  * Interface representing a bound module within a program

--- a/src/types/saveFile.ts
+++ b/src/types/saveFile.ts
@@ -17,13 +17,12 @@
  * @module savefile
  */
 
-import {CommandResult, FilteredItem, IBMiObject} from "@halcyontech/vscode-ibmi-types";
-import { basename } from "path";
+import {CommandResult, IBMiObject} from "@halcyontech/vscode-ibmi-types";
 import * as vscode from "vscode";
-import { FastTableColumn, IBMI_OBJECT_NAME, generateDetailTable, generateFastTable, getProtected, getQSYSObjectPath, checkViewExists, checkTableFunctionExists, executeSqlIfExists } from "../tools";
+import { FastTableColumn, generateDetailTable, generateFastTable, getProtected, getQSYSObjectPath, executeSqlIfExists } from "../tools";
 import { Components } from "../webviewToolkit";
 import Base from "./base";
-import { getInstance, getVSCodeTools } from "../ibmi";
+import { getInstance } from "../ibmi";
 import { Tools } from "@halcyontech/vscode-ibmi-types/api/Tools";
 import path = require("path");
 import ObjectProvider from '../objectProvider';
@@ -1289,6 +1288,7 @@ export class SaveFile extends Base {
       const savf: CommandResult = await connection.runCommand({
         command: `QSYS/DSPSAVF FILE(${this.library}/${this.name})`,
         environment: `ile`,
+        getSpooledFiles:true,
       });
 
       if (savf.code === 0 && savf.stdout) {

--- a/src/types/subsystemDescription.ts
+++ b/src/types/subsystemDescription.ts
@@ -26,7 +26,7 @@ import * as vscode from 'vscode';
 import { Components } from "../webviewToolkit";
 import Base from "./base";
 import { getInstance } from '../ibmi';
-import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, checkViewExists, checkTableFunctionExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, executeSqlIfExists } from "../tools";
 import ObjectProvider from '../objectProvider';
 import { JobOperations } from '../commonOperations';
 

--- a/src/types/userIndex.ts
+++ b/src/types/userIndex.ts
@@ -16,13 +16,13 @@
  * @module userIndex
  */
 
-import { CommandResult, IBMiObject } from '@halcyontech/vscode-ibmi-types';
+import { IBMiObject } from '@halcyontech/vscode-ibmi-types';
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
 import * as vscode from 'vscode';
 import { Components } from "../webviewToolkit";
 import Base from "./base";
 import { getInstance } from '../ibmi';
-import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, checkProcedureExists, checkTableFunctionExists, checkViewExists, executeSqlIfExists } from "../tools";
+import { getColumns, generateDetailTable, FastTableColumn, generateFastTable, getProtected, executeSqlIfExists } from "../tools";
 import ObjectProvider from '../objectProvider';
 
 /**

--- a/src/types/userSpace.ts
+++ b/src/types/userSpace.ts
@@ -16,11 +16,9 @@
  */
 
 import Base from "./base";
-import { IBMiObject, CommandResult } from '@halcyontech/vscode-ibmi-types';
-import { Components } from "../webviewToolkit";
+import { IBMiObject } from '@halcyontech/vscode-ibmi-types';
 import { getInstance } from "../ibmi";
-import { getColumns, generateDetailTable, getProtected, checkTableFunctionExists, checkProcedureExists, checkViewExists, executeSqlIfExists } from "../tools";
-import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
+import { getColumns, generateDetailTable, getProtected, executeSqlIfExists } from "../tools";
 import * as vscode from 'vscode';
 import ObjectProvider from '../objectProvider';
 

--- a/src/views/dspobj.ts
+++ b/src/views/dspobj.ts
@@ -10,7 +10,7 @@
 import { IBMiObject } from '@halcyontech/vscode-ibmi-types';
 import * as vscode from 'vscode';
 import { getInstance } from '../ibmi';
-import { FastTableColumn, generateDetailTable, generateFastTable, executeSqlIfExists, checkTableFunctionExists, checkViewExists } from "../tools";
+import { FastTableColumn, generateDetailTable, generateFastTable, executeSqlIfExists } from "../tools";
 import { Components } from "../webviewToolkit";
 
 /**

--- a/src/views/wrkjob.ts
+++ b/src/views/wrkjob.ts
@@ -15,7 +15,7 @@
 
 import * as vscode from 'vscode';
 import { getInstance } from '../ibmi';
-import { FastTableColumn, generateFastTable, generateDetailTable, executeSqlIfExists, checkTableFunctionExists, getColumns } from "../tools";
+import { FastTableColumn, generateFastTable, generateDetailTable, executeSqlIfExists } from "../tools";
 import { generatePage, Components } from "../webviewToolkit";
 import { JobOperations, SpoolOperations } from '../commonOperations';
 import { Tools } from '@halcyontech/vscode-ibmi-types/api/Tools';
@@ -59,10 +59,30 @@ export namespace WrkjobActions {
     context.subscriptions.push(
       vscode.commands.registerCommand("vscode-ibmi-fs.wrkjob", async (jobName?: string) => {
         if (!jobName) {
+          const ibmi = getInstance();
+          const connection = ibmi?.getConnection();
+          if (!connection) {
+            throw new Error(vscode.l10n.t("Not connected to IBM i"));
+          }
+
+          const thejob = await executeSqlIfExists(
+            connection,
+            `select JOB_NAME AS JOBNAME from table(qsys2.active_job_info(job_name_filter => '*', detailed_info => 'NONE'))`,
+            'QSYS2',
+            'ACTIVE_JOB_INFO',
+            'FUNCTION'
+          );
+
+          if (thejob === null) {
+            vscode.window.showErrorMessage(vscode.l10n.t("SQL {0} {1}/{2} not found. Please check your IBM i system.", "FUNCTION", "QSYS2", "ACTIVE_JOB_INFO"));
+            return;
+          }
+
           // Prompt user for job name if not provided
           jobName = await vscode.window.showInputBox({
             placeHolder: vscode.l10n.t("000000/USER/MYJOB"),
             title: vscode.l10n.t("Enter job name (number/user/name)"),
+            value: thejob[0].JOBNAME,
             validateInput: (value) => {
               const parts = value.split('/');
               if (parts.length !== 3) {
@@ -429,6 +449,7 @@ export namespace WrkjobActions {
     const liblspl = await connection.runCommand({
       command: `QSYS/DSPJOB JOB(${jobName}) OPTION(*LIBL)`,
       environment: `ile`,
+      getSpooledFiles:true,
     });
 
     if (!liblspl || !liblspl.stdout) {
@@ -440,18 +461,13 @@ export namespace WrkjobActions {
     const lines = liblspl.stdout.split('\n');
     const libraries: LibraryEntry[] = [];
     
-    for (const line of lines) {
-      // Skip empty lines and lines that don't start with spaces (headers, etc.)
-      // Minimum length is 24 to include library name and type
-      if (line.length < 16 || !line.startsWith('    ')) {
-        continue;
-      }
+  for (const line of lines) {
       
       // Extract fields by position (fixed-width columns)
-      const library = line.substring(4, 14).trim();
-      const type = line.substring(16, 19).trim();
-      const asp = line.substring(27, 37).trim();
-      const description = line.substring(39, 90).trim();
+      const library = line.substring(3, 13).trim();
+      const type = line.substring(15, 18).trim();
+      const asp = line.substring(26, 36).trim();
+      const description = line.substring(38, 90).trim();
       
       // Skip if library name is empty or starts with * (separator lines)
       if (!library || library.startsWith('*')) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"lib": [
 			"ES2022"
 		],
+		"types": ["node"],
 		"sourceMap": true,
 		"rootDir": "src",
 		"strict": true   /* enable all strict type-checking options */


### PR DESCRIPTION
### Changes
This update updates the dependencies to use version 3.0.6 of the core extension and fixes the spool-opening function to convert to 1208

### Checklist
<!-- Put an `x` in the relevant boxes -->
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [ ] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
close #46
