### PR TITLE
fix: change temp dir reference to use getTempDirectory method

### DIFF
--- a/src/commonOperations.ts
+++ b/src/commonOperations.ts
@@ -14,11 +14,11 @@
  * @module commonOperations
  */
 
-import * as vscode from 'vscode';
 import { CommandResult } from '@halcyontech/vscode-ibmi-types';
+import { posix } from 'path';
+import * as vscode from 'vscode';
 import { getInstance } from './ibmi';
 import { checkTableFunctionExists } from './tools';
-import { posix } from 'path';
 
 /**
  * Interface representing a job identifier
@@ -54,7 +54,7 @@ export namespace JobOperations {
   export const holdJob = async (jobId: JobIdentifier, showConfirmation: boolean = true): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -107,7 +107,7 @@ export namespace JobOperations {
   export const releaseJob = async (jobId: JobIdentifier, showConfirmation: boolean = true): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -165,7 +165,7 @@ export namespace JobOperations {
   ): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -217,7 +217,7 @@ export namespace JobOperations {
   export const debugJob = async (job: JobIdentifier): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -277,7 +277,7 @@ export namespace SpoolOperations {
   ): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -336,7 +336,7 @@ export namespace SpoolOperations {
   ): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -344,7 +344,7 @@ export namespace SpoolOperations {
 
     try {
       // Create a temporary directory and copy the spool file to it
-      return connection.withTempDirectory(async (tempDir) : Promise<boolean> => {
+      return connection.withTempDirectory(async (tempDir): Promise<boolean> => {
         // Generate temporary file path for the spool content
         const tempSourcePath = posix.join(tempDir, `spool.txt`);
 
@@ -355,7 +355,7 @@ export namespace SpoolOperations {
           environment: 'ile'
         });
 
-        if(result.code===0){
+        if (result.code === 0) {
           // Create URI for the temporary file and open it in VS Code as readonly
           const uri = vscode.Uri.parse(tempSourcePath).with({
             scheme: `streamfile`
@@ -364,7 +364,7 @@ export namespace SpoolOperations {
             preview: false,
             preserveFocus: false
           });
-          
+
           return true;
         } else {
           vscode.window.showErrorMessage(
@@ -394,7 +394,7 @@ export namespace SpoolOperations {
   ): Promise<boolean> => {
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
-    
+
     if (!connection) {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
@@ -433,9 +433,9 @@ export namespace SpoolOperations {
 
       try {
         const config = connection.getConfig();
-        const tempRemotePath = config.tempDir + '/' + 
-          spoolId.job.replaceAll("/", "_") + '_' + 
-          spoolId.spoolname + '_' + 
+        const tempRemotePath = connection.getTempDirectory() + '/' +
+          spoolId.job.replaceAll("/", "_") + '_' +
+          spoolId.spoolname + '_' +
           spoolId.nbr + '.pdf';
 
         // Generate PDF on IBM i

--- a/src/types/class.ts
+++ b/src/types/class.ts
@@ -23,11 +23,11 @@
  * @module class
  */
 
-import Base from "./base";
-import { getInstance } from "../ibmi";
-import { generateDetailTable, checkProcedureExists, checkViewExists, checkTableFunctionExists } from "../tools";
-import * as vscode from 'vscode';
 import { CommandResult } from "@halcyontech/vscode-ibmi-types";
+import * as vscode from 'vscode';
+import { getInstance } from "../ibmi";
+import { checkProcedureExists, checkTableFunctionExists, checkViewExists, generateDetailTable } from "../tools";
+import Base from "./base";
 
 /**
  * Class (CLS) object class
@@ -70,22 +70,22 @@ export default class Cls extends Base {
       // Check if required SQL objects exist in the temporary library
       // We need: QWCRCLSI procedure, CLASS_INFO view, and CLASS_INFO function
       const tempLib = connection.getConfig().tempLibrary;
-      
+
       const procedureExists = await checkProcedureExists(connection, tempLib, 'QWCRCLSI');
       const viewExists = await checkViewExists(connection, tempLib, 'CLASS_INFO');
       const functionExists = await checkTableFunctionExists(connection, tempLib, 'CLASS_INFO');
-     
-     // If any of the 3 required objects are missing, create them all
-     if(!procedureExists || !viewExists || !functionExists){
-       try{
-         // Write SQL script to create the required objects
-          const content=connection.getContent();
-          if(content){
+
+      // If any of the 3 required objects are missing, create them all
+      if (!procedureExists || !viewExists || !functionExists) {
+        try {
+          // Write SQL script to create the required objects
+          const content = connection.getContent();
+          if (content) {
             // Create SQL script that defines:
             // 1. QWCRCLSI stored procedure (wrapper for QWCRCLSI API)
             // 2. CLASS_INFO table function (retrieves all classes)
             // 3. CLASS_INFO view (exposes the function results)
-            await content.writeStreamfileRaw(connection.getConfig().tempDir+'/clsbuild.sql',`
+            await content.writeStreamfileRaw(connection.getTempDirectory() + '/clsbuild.sql', `
               --
               -- Subject: Finding IBM i class objects and return the class attributes
               -- Author: Scott Forstie
@@ -128,13 +128,13 @@ export default class Cls extends Base {
               CREATE OR REPLACE FUNCTION ${connection.getConfig().tempLibrary}.class_info ()
                   RETURNS TABLE (
                       class_library VARCHAR(10) FOR SBCS DATA,
-                      class_name VARCHAR(10) FOR SBCS DATA, 
+                      class_name VARCHAR(10) FOR SBCS DATA,
                       text_description VARCHAR(50) FOR SBCS DATA,
-                      last_used date, 
-                      use_count INTEGER, 
+                      last_used date,
+                      use_count INTEGER,
                       run_priority INTEGER,
                       eligible_purge VARCHAR(4) FOR SBCS DATA,
-                      time_slice INTEGER, 
+                      time_slice INTEGER,
                       default_wait VARCHAR(11) FOR SBCS DATA,
                       maximum_cpu_time  VARCHAR(11) FOR SBCS DATA,
                       maximum_temporary_storage_allowed VARCHAR(11) FOR SBCS DATA,
@@ -237,10 +237,10 @@ export default class Cls extends Base {
                               ${connection.getConfig().tempLibrary}.class_info()
                           );
             `)
-            
+
             // Execute the SQL script to create the objects
             const runsql: CommandResult = await connection.runCommand({
-              command: `QSYS/RUNSQLSTM SRCSTMF('${connection.getConfig().tempDir}/clsbuild.sql') COMMIT(*NONE)`,
+              command: `QSYS/RUNSQLSTM SRCSTMF('${connection.getTempDirectory()}/clsbuild.sql') COMMIT(*NONE)`,
               environment: `ile`,
             });
 
@@ -250,7 +250,7 @@ export default class Cls extends Base {
             } else {
               // Clean up the temporary SQL script file
               await connection.runCommand({
-                command: `rm -f ${connection.getConfig().tempDir}/clsbuild.sql`,
+                command: `rm -f ${connection.getTempDirectory()}/clsbuild.sql`,
                 environment: `pase`,
               });
             }
@@ -267,7 +267,7 @@ export default class Cls extends Base {
 
       // Define column mappings for display
       // Maps database column names to user-friendly display labels
-      this.columns= new Map<string,string>([
+      this.columns = new Map<string, string>([
         ['TEXT_DESCRIPTION', vscode.l10n.t('Text')],
         ['LAST_USED_TIMESTAMP', vscode.l10n.t('Last used date')],
         ['USE_COUNT', vscode.l10n.t('Days used count')],
@@ -318,7 +318,7 @@ export default class Cls extends Base {
       subtitle: vscode.l10n.t('Class Information'),
       columns: this.columns,
       data: this.cls,
-      hideNullValues:true
+      hideNullValues: true
     });
   }
 

--- a/src/types/saveFile.ts
+++ b/src/types/saveFile.ts
@@ -17,15 +17,15 @@
  * @module savefile
  */
 
-import {CommandResult, IBMiObject} from "@halcyontech/vscode-ibmi-types";
+import { CommandResult, IBMiObject } from "@halcyontech/vscode-ibmi-types";
+import { Tools } from "@halcyontech/vscode-ibmi-types/api/Tools";
 import * as vscode from "vscode";
-import { FastTableColumn, generateDetailTable, generateFastTable, getProtected, getQSYSObjectPath, executeSqlIfExists } from "../tools";
+import { getInstance } from "../ibmi";
+import ObjectProvider from '../objectProvider';
+import { executeSqlIfExists, FastTableColumn, generateDetailTable, generateFastTable, getProtected, getQSYSObjectPath } from "../tools";
 import { Components } from "../webviewToolkit";
 import Base from "./base";
-import { getInstance } from "../ibmi";
-import { Tools } from "@halcyontech/vscode-ibmi-types/api/Tools";
 import path = require("path");
-import ObjectProvider from '../objectProvider';
 
 /**
  * Namespace containing all Save File related actions and commands
@@ -131,7 +131,7 @@ export namespace SaveFileActions {
   export const downloadSavf = async (target: IBMiObject | SaveFile) => {
     const library = target.library.toUpperCase();
     const name = target.name.toUpperCase();
-    
+
     const ibmi = getInstance();
     const connection = ibmi?.getConnection();
     if (connection) {
@@ -187,7 +187,7 @@ export namespace SaveFileActions {
             };
 
             const config = connection.getConfig();
-            const tempRemotePath = `${config.tempDir}/${library}_${name}.savf`;
+            const tempRemotePath = `${connection.getTempDirectory()}/${library}_${name}.savf`;
 
             // Step 1: Copy save file to temporary stream file
             progress.report({ message: vscode.l10n.t("Copying to temporary stream file...") });
@@ -238,7 +238,7 @@ export namespace SaveFileActions {
       }
     } else {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
-    } 
+    }
   };
 
   /**
@@ -253,7 +253,7 @@ export namespace SaveFileActions {
     const connection = ibmi?.getConnection();
 
     if (connection) {
-      if(getProtected(connection,target.library)){
+      if (getProtected(connection, target.library)) {
         vscode.window.showWarningMessage(vscode.l10n.t("Unable to perform object action because it is protected."));
         return false;
       }
@@ -302,7 +302,7 @@ export namespace SaveFileActions {
 
             let lclpath = saveFiles[0].path;
             let rmtpath = path.posix.join(
-              connection.getConfig().tempDir,
+              connection.getTempDirectory(),
               path.basename(lclpath),
             );
 
@@ -348,7 +348,7 @@ export namespace SaveFileActions {
               command: `rm -f ${rmtpath}`,
               environment: `pase`,
             });
-            
+
             return result;
           },
         );
@@ -370,7 +370,7 @@ export namespace SaveFileActions {
       vscode.window.showErrorMessage(vscode.l10n.t("Not connected to IBM i"));
       return false;
     }
-      
+
   };
 
   /**
@@ -385,7 +385,7 @@ export namespace SaveFileActions {
     const connection = ibmi?.getConnection();
 
     if (connection) {
-      if(getProtected(connection,target.library)){
+      if (getProtected(connection, target.library)) {
         vscode.window.showWarningMessage(vscode.l10n.t("Unable to perform object action because it is protected."));
         return false;
       }
@@ -423,7 +423,7 @@ export namespace SaveFileActions {
     const connection = ibmi?.getConnection();
 
     if (connection) {
-      if(getProtected(connection,target.library)){
+      if (getProtected(connection, target.library)) {
         vscode.window.showWarningMessage(vscode.l10n.t("Unable to perform object action because it is protected."));
         return false;
       }
@@ -479,7 +479,7 @@ export namespace SaveFileActions {
           // Get the library name from save file info if not QSYS/SAV command
           if (saveCmd !== "SAV") {
             const libResult = await connection.runSQL(
-              `SELECT LIBRARY_NAME 
+              `SELECT LIBRARY_NAME
                 FROM QSYS2.SAVE_FILE_INFO WHERE
                 SAVE_FILE_LIBRARY = '${target.library}' AND SAVE_FILE = '${target.name}'`,
             );
@@ -833,7 +833,7 @@ export namespace SaveFileActions {
     const connection = ibmi?.getConnection();
 
     if (connection) {
-      if(getProtected(connection,target.library)){
+      if (getProtected(connection, target.library)) {
         vscode.window.showWarningMessage(vscode.l10n.t("Unable to perform object action because it is protected."));
         return false;
       }
@@ -857,7 +857,7 @@ export namespace SaveFileActions {
         vscode.window.showErrorMessage(vscode.l10n.t("Save file {0}/{1} is not empty", target.library, target.name));
         return false;
       }
-      
+
       const result = await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
@@ -1288,7 +1288,7 @@ export class SaveFile extends Base {
       const savf: CommandResult = await connection.runCommand({
         command: `QSYS/DSPSAVF FILE(${this.library}/${this.name})`,
         environment: `ile`,
-        getSpooledFiles:true,
+        getSpooledFiles: true,
       });
 
       if (savf.code === 0 && savf.stdout) {


### PR DESCRIPTION
### Changes
Changed the temp dir to use the getTempDirectory method instead of directly accessing the config.tempDir.
The config.tempDir is changed to look like "\~/.vscode/tmp" the method will resolve it to "/home/\<username\>/.vscode/tmp".
Otherwise, the folder “/home/\<username\>/~/.vscode/tmp” is used.

### How to test this PR
Uploading a SAVF from local to the IBM i now should not use the “\~” folder in the Home directory of the user and uses the correct Folder.

### Checklist
* [X] have tested my change