### PR TITLE
Fixed spool name

### DIFF
--- a/src/commonOperations.ts
+++ b/src/commonOperations.ts
@@ -346,7 +346,7 @@ export namespace SpoolOperations {
       // Create a temporary directory and copy the spool file to it
       return connection.withTempDirectory(async (tempDir): Promise<boolean> => {
         // Generate temporary file path for the spool content
-        const tempSourcePath = posix.join(tempDir, `spool.txt`);
+        const tempSourcePath = posix.join(tempDir, `${spoolId.job.replaceAll('/', '-')}_${spoolId.spoolname}_${spoolId.nbr}.txt`);
 
         // Execute CPYSPLF command to copy spool to stream file
         const result = await connection.runCommand({


### PR DESCRIPTION
### Changes
This pr change file name when you open a spool from WRKSPLF or from OUTQ.

### How to test this PR
Open a spool, now the file has a different name than spool.txt:
![Uploading image.png…]()


### Checklist
* [x] have tested my change
* [ ] have created one or more test cases
* [ ] updated relevant documentation
* [ ] Remove any/all `console.log`s I added
* [x] have added myself to the contributors' list in [CONTRIBUTING.md](https://github.com/codefori/vscode-ibmi/blob/master/CONTRIBUTING.md)
