### PR TITLE
Show short (system) column name in File Columns view

### DIFF
--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "Bewertung",
   "Shared": "Gemeinsam",
   "SHARED_ACTIVATION_GROUP": "Gemeinsam benutzte Aktivierungsgruppe",
+  "Short name": "Kurzname",
   "SIALI": "Aliasnamenkomponente (Byte)",
   "SIALIL": "Alias-Komponentenbegrenzung",
   "SIASP": "Zugeordneter Speicherbereich (Byte)",

--- a/l10n/bundle.l10n.en.json
+++ b/l10n/bundle.l10n.en.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "Severity",
   "Shared": "Shared",
   "SHARED_ACTIVATION_GROUP": "Shared Activation Group",
+  "Short name": "Short name",
   "SIALI": "Alias Component (bytes)",
   "SIALIL": "Alias Component Limit",
   "SIASP": "Associated Space (bytes)",

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "Gravedad",
   "Shared": "Compartido",
   "SHARED_ACTIVATION_GROUP": "Grupo de Activación Compartido",
+  "Short name": "Nombre corto",
   "SIALI": "Componente alias (bytes)",
   "SIALIL": "Límite de componentes alias",
   "SIASP": "Espacio asociado (bytes)",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "Gravité",
   "Shared": "Partagé",
   "SHARED_ACTIVATION_GROUP": "Groupe d'activation partagé",
+  "Short name": "Nom court",
   "SIALI": "Composant alias (octets)",
   "SIALIL": "Limite des composants alias",
   "SIASP": "Espace associé (octets)",

--- a/l10n/bundle.l10n.it.json
+++ b/l10n/bundle.l10n.it.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "Gravità",
   "Shared": "Condiviso",
   "SHARED_ACTIVATION_GROUP": "Activation group condiviso",
+  "Short name": "Nome breve",
   "SIALI": "Componente alias (byte)",
   "SIALIL": "Limite componente alias",
   "SIASP": "Spazio associato (byte)",

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "重大度",
   "Shared": "共有",
   "SHARED_ACTIVATION_GROUP": "共用活動化グループ",
+  "Short name": "短縮名",
   "SIALI": "別名構成要素（バイト）",
   "SIALIL": "エイリアス コンポーネント制限",
   "SIASP": "関連したスペース（バイト）",

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "심각도",
   "Shared": "공유됨",
   "SHARED_ACTIVATION_GROUP": "공유　활성　그룹",
+  "Short name": "짧은 이름",
   "SIALI": "별명　구성요소(바이트)",
   "SIALIL": "별칭 구성 요소 제한",
   "SIASP": "연관된　공간(바이트)",

--- a/l10n/bundle.l10n.pt-br.json
+++ b/l10n/bundle.l10n.pt-br.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "Gravidade",
   "Shared": "Compartilhado",
   "SHARED_ACTIVATION_GROUP": "Grupo de Ativação Compartilhado",
+  "Short name": "Nome curto",
   "SIALI": "Componente nomes alternativos (bytes)",
   "SIALIL": "Limite de componentes de alias",
   "SIASP": "Espaço associado (bytes)",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -1193,6 +1193,7 @@
   "SEVERITY": "严重性",
   "Shared": "共享",
   "SHARED_ACTIVATION_GROUP": "共享激活组",
+  "Short name": "短名称",
   "SIALI": "别名部件（字节）",
   "SIALIL": "别名组件限制",
   "SIASP": "相关空间（字节）",

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -1194,6 +1194,7 @@
   "SEVERITY": "嚴重性",
   "Shared": "共用",
   "SHARED_ACTIVATION_GROUP": "共用啟動群組",
+  "Short name": "簡稱",
   "SIALI": "別名元件（位元組）",
   "SIALIL": "別名元件限制",
   "SIASP": "相關的空間（位元組）",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,7 +1005,6 @@
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1039,7 +1038,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1148,7 +1146,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -3374,7 +3371,6 @@
       "integrity": "sha512-2t3XstrKULz41MNMBF+cJ97TyHdyQ8HCt//pqErqDvNjU9YQBnZxIHa11VXsi7F3mb5/aO2tuDxdeTPdU7xu9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -3422,7 +3418,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -115,6 +115,8 @@ interface Member {
 interface Column {
   /** Column name */
   name: string
+  /** Short column name (system) */
+  shortName: string
   /** Ordinal position in the table */
   position: number
   /** Data type of the column */
@@ -308,6 +310,7 @@ export default class File extends Base {
       const entryRows = await executeSqlIfExists(
         connection,
         `SELECT COLUMN_NAME,
+            SYSTEM_COLUMN_NAME,
             ORDINAL_POSITION,
             DATA_TYPE,
             LENGTH,
@@ -764,6 +767,7 @@ export default class File extends Base {
   private toColumn(row: Tools.DB2Row): Column {
     return {
       name: String(row.COLUMN_NAME),
+      shortName: String(row.SYSTEM_COLUMN_NAME),
       position: Number(row.ORDINAL_POSITION),
       datatype: String(row.DATA_TYPE),
       length: Number(row.LENGTH),
@@ -856,6 +860,7 @@ export default class File extends Base {
     // Define table columns with their properties
     const columns: FastTableColumn<Column>[] = [
       { title: vscode.l10n.t("Column name"), width: "1fr", getValue: e => e.name  },
+      { title: vscode.l10n.t("Short name"), width: "0.7fr", getValue: e => e.shortName !== e.name ? e.shortName : '' },
       { title: vscode.l10n.t("Position"), width: "0.3fr", getValue: e => e.position },
       { title: vscode.l10n.t("Data type"), width: "0.7fr", getValue: e => e.datatype },
       { title: vscode.l10n.t("Length"), width: "0.5fr", getValue: e => e.length },

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -336,8 +336,8 @@ export default class File extends Base {
             COLUMN_DEFAULT,
             COLUMN_TEXT
           FROM QSYS2.SYSCOLUMNS
-          WHERE TABLE_NAME = '${this.name}'
-                AND TABLE_SCHEMA = '${this.library}'`,
+          WHERE SYSTEM_TABLE_NAME = '${this.name}'
+                AND SYSTEM_TABLE_SCHEMA = '${this.library}'`,
         'QSYS2',
         'SYSCOLUMNS',
         'VIEW'
@@ -512,8 +512,8 @@ export default class File extends Base {
           DATA_SIZE,
           TEXT_DESCRIPTION
         FROM QSYS2.SYSMEMBERSTAT
-        WHERE TABLE_SCHEMA = '${this.library}'
-              AND TABLE_NAME = '${this.name}'`,
+        WHERE SYSTEM_TABLE_SCHEMA = '${this.library}'
+              AND SYSTEM_TABLE_NAME = '${this.name}'`,
         'QSYS2',
         'SYSMEMBERSTAT',
         'VIEW'


### PR DESCRIPTION
### Changes
Adds the short (system) column name (`SYSTEM_COLUMN_NAME` from `QSYS2.SYSCOLUMNS`) as a new column in the File Columns view. RPG programs still reference fields by their short/DDS-style name, so this makes it easier to map SQL column names back to what's used in RPG source.

The new "Short name" column is left blank (styled placeholder) when it's identical to the long column name, to avoid redundant noise on tables where both names match.

### How to test this PR
1. Connect to an IBM i system
2. Open a physical file / table with SQL-created long column names (or any table) via the Object Editor
3. Go to the "File Columns" tab
4. Confirm the new "Short name" column shows the system column name, blank when it matches the long name