### PR TITLE
Fix empty message in File Columns view

### DIFF
--- a/l10n/bundle.l10n.de.json
+++ b/l10n/bundle.l10n.de.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "Kein AJE für dieses Subsystem.",
   "No authorizations found": "Keine Berechtigungen gefunden",
   "No call stack entries found.": "Keine Call-Stack-Einträge gefunden.",
+  "No columns found": "Keine Spalten gefunden",
   "No copyright information in this module.": "Dieses Modul enthält keine Copyright-Informationen.",
   "No data in this Usridx.": "Keine Daten in diesem Usridx.",
   "No dependent objects found": "Keine abhängigen Objekte gefunden",

--- a/l10n/bundle.l10n.en.json
+++ b/l10n/bundle.l10n.en.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "No AJE for this subsystem.",
   "No authorizations found": "No authorizations found",
   "No call stack entries found.": "No call stack entries found.",
+  "No columns found": "No columns found",
   "No copyright information in this module.": "No copyright information in this module.",
   "No data in this Usridx.": "No data in this Usridx.",
   "No dependent objects found": "No dependent objects found",

--- a/l10n/bundle.l10n.es.json
+++ b/l10n/bundle.l10n.es.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "No hay AJE para este subsistema.",
   "No authorizations found": "No se encontraron autorizaciones",
   "No call stack entries found.": "No se encontraron entradas en la pila de llamadas.",
+  "No columns found": "No se encontraron columnas",
   "No copyright information in this module.": "No hay información sobre derechos de autor en este módulo.",
   "No data in this Usridx.": "No hay datos en este Usridx.",
   "No dependent objects found": "No se han encontrado objetos dependientes",

--- a/l10n/bundle.l10n.fr.json
+++ b/l10n/bundle.l10n.fr.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "Pas d'AJE pour ce sous-système.",
   "No authorizations found": "Aucune autorisation trouvée",
   "No call stack entries found.": "Aucune entrée dans la pile d'appels.",
+  "No columns found": "Aucune colonne trouvée",
   "No copyright information in this module.": "Aucune information relative aux droits d'auteur dans ce module.",
   "No data in this Usridx.": "Aucune donnée dans cet Usridx.",
   "No dependent objects found": "Aucun objet dépendant trouvé",

--- a/l10n/bundle.l10n.it.json
+++ b/l10n/bundle.l10n.it.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "Nessun AJE per questo sottosistema.",
   "No authorizations found": "Nessuna autorizzazione trovata",
   "No call stack entries found.": "Nessuna voce nel call stack.",
+  "No columns found": "Nessuna colonna trovata",
   "No copyright information in this module.": "Nessuna informazione copyright in questo modulo.",
   "No data in this Usridx.": "Nessun dato in questo Usridx.",
   "No dependent objects found": "Nessun oggetto dipendente trovato",

--- a/l10n/bundle.l10n.ja.json
+++ b/l10n/bundle.l10n.ja.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "このサブシステムにはAJEはありません。",
   "No authorizations found": "権限が見つかりません",
   "No call stack entries found.": "コール・スタックのエントリがありません。",
+  "No columns found": "列が見つかりません",
   "No copyright information in this module.": "このモジュールには著作権情報がありません。",
   "No data in this Usridx.": "このUsridxにデータがありません。",
   "No dependent objects found": "依存オブジェクトが見つかりませんでした",

--- a/l10n/bundle.l10n.ko.json
+++ b/l10n/bundle.l10n.ko.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "이 하위 시스템에는 AJE가 없습니다.",
   "No authorizations found": "권한을 찾을 수 없습니다",
   "No call stack entries found.": "호출 스택 항목이 없습니다.",
+  "No columns found": "열을 찾을 수 없습니다",
   "No copyright information in this module.": "이 모듈에는 저작권 정보가 없습니다.",
   "No data in this Usridx.": "이 Usridx에 데이터가 없습니다.",
   "No dependent objects found": "종속 객체가 발견되지 않았습니다",

--- a/l10n/bundle.l10n.pt-br.json
+++ b/l10n/bundle.l10n.pt-br.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "Sem AJE para este subsistema.",
   "No authorizations found": "Nenhuma autorização encontrada",
   "No call stack entries found.": "Nenhuma entrada na pilha de chamadas.",
+  "No columns found": "Nenhuma coluna encontrada",
   "No copyright information in this module.": "Não há informações sobre direitos autorais neste módulo.",
   "No data in this Usridx.": "Nenhum dado neste Usridx.",
   "No dependent objects found": "Nenhum objeto dependente encontrado",

--- a/l10n/bundle.l10n.zh-cn.json
+++ b/l10n/bundle.l10n.zh-cn.json
@@ -861,6 +861,7 @@
   "No AJE for this subsystem.": "此子系统不支持AJE。",
   "No authorizations found": "未找到授权",
   "No call stack entries found.": "未找到调用栈条目。",
+  "No columns found": "未找到列",
   "No copyright information in this module.": "本模块中没有版权信息。",
   "No data in this Usridx.": "此Usridx中没有数据。",
   "No dependent objects found": "未找到任何依赖对象",

--- a/l10n/bundle.l10n.zh-tw.json
+++ b/l10n/bundle.l10n.zh-tw.json
@@ -862,6 +862,7 @@
   "No AJE for this subsystem.": "此子系統不適用AJE。",
   "No authorizations found": "找不到授權",
   "No call stack entries found.": "未找到呼叫堆疊項目。",
+  "No columns found": "未找到欄位",
   "No copyright information in this module.": "本模組不含版權資訊。",
   "No data in this Usridx.": "此Usridx中沒有資料。",
   "No dependent objects found": "未找到任何依賴物件",

--- a/src/types/file.ts
+++ b/src/types/file.ts
@@ -878,7 +878,7 @@ export default class File extends Base {
       columns: columns,
       data: this.fileColumns,
       stickyHeader: true,
-      emptyMessage: vscode.l10n.t('No members objects found'),
+      emptyMessage: vscode.l10n.t('No columns found'),
     }) + ``;
   }
 


### PR DESCRIPTION
Fixes a message bug where the File Columns tab showed the members' empty-state message instead of its own.